### PR TITLE
Add naive buffer pool

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+	"rust-analyzer.inlayHints.lifetimeElisionHints.enable": "always",
+	"rust-analyzer.inlayHints.lifetimeElisionHints.useParameterNames": true
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 eyre = "0.6.8"
 futures = "0.3.24"
 httparse = "1.8.0"
+memmap2 = "0.5.7"
+thiserror = "1.0.37"
 tokio = { version = "1.21.2", features = ["full"] }
 # this includes a fix for accept
 tokio-uring = { git = "https://github.com/tokio-rs/tokio-uring", rev = "a42af77" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "alt-http"
 version = "0.1.0"
 edition = "2021"
 
+[[bench]]
+name = "simple"
+harness = false
+
 [dependencies]
 eyre = "0.6.8"
 futures = "0.3.24"
@@ -16,5 +20,6 @@ tracing = "0.1.37"
 
 [dev-dependencies]
 color-eyre = "0.6.2"
+criterion = "0.4.0"
 hyper = { version = "0.14.20", features = ["client", "server", "http1", "tcp", "stream"] }
 tracing-subscriber = "0.3.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "alt-http"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+bench = false
+
 [[bench]]
 name = "simple"
 harness = false

--- a/Justfile
+++ b/Justfile
@@ -6,3 +6,6 @@ _default:
 # Run all tests with cargo nextest
 test *args:
 	RUST_BACKTRACE=1 cargo nextest run {{args}}
+
+bench *args:
+	RUST_BACKTRACE=1 cargo bench {{args}}

--- a/Justfile
+++ b/Justfile
@@ -8,4 +8,4 @@ test *args:
 	RUST_BACKTRACE=1 cargo nextest run {{args}}
 
 bench *args:
-	RUST_BACKTRACE=1 cargo bench {{args}}
+	RUST_BACKTRACE=1 cargo bench {{args}} -- --plotting-backend plotters

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -8,42 +8,30 @@ static INPUT: &[u8] = b"This is some sample data";
 fn bench_bufpool(c: &mut Criterion) {
     let mut g = c.benchmark_group("alloc");
 
-    g.bench_function("noop", |b| b.iter_with_setup(|| {}, |_| {}));
-    g.bench_function("buf-unchecked", |b| {
-        b.iter_with_setup(
-            || {
-                alt_http::bufpool::init().unwrap();
-            },
-            |_| {
-                let mut buf = alt_http::bufpool::Buf::alloc_unchecked().unwrap();
-                buf[..INPUT.len()].copy_from_slice(INPUT);
-                assert_eq!(&buf[..INPUT.len()], INPUT);
-                black_box(&buf[..]);
-            },
-        )
+    g.bench_function("0-stack", |b| {
+        b.iter(|| {
+            let mut buf = [0u8; 4096];
+            buf[..INPUT.len()].copy_from_slice(INPUT);
+            assert_eq!(&buf[..INPUT.len()], INPUT);
+            black_box(&buf[..]);
+        })
     });
-    g.bench_function("buf-checked", |b| {
-        b.iter_with_setup(
-            || {},
-            |_| {
-                let mut buf = alt_http::bufpool::Buf::alloc().unwrap();
-                buf[..INPUT.len()].copy_from_slice(INPUT);
-                assert_eq!(&buf[..INPUT.len()], INPUT);
-                black_box(&buf[..]);
-            },
-        )
+    g.bench_function("1-pool", |b| {
+        b.iter(|| {
+            let mut buf = alt_http::bufpool::Buf::alloc().unwrap();
+            buf[..INPUT.len()].copy_from_slice(INPUT);
+            assert_eq!(&buf[..INPUT.len()], INPUT);
+            black_box(&buf[..]);
+        })
     });
-    g.bench_function("vec", |b| {
-        b.iter_with_setup(
-            || {},
-            |_| {
-                let mut buf: Vec<u8> = Vec::with_capacity(4096);
-                buf.resize(INPUT.len(), 0);
-                buf[..INPUT.len()].copy_from_slice(INPUT);
-                assert_eq!(&buf[..INPUT.len()], INPUT);
-                black_box(&buf[..]);
-            },
-        )
+    g.bench_function("2-vec", |b| {
+        b.iter(|| {
+            let mut buf: Vec<u8> = Vec::with_capacity(4096);
+            buf.resize(INPUT.len(), 0);
+            buf[..INPUT.len()].copy_from_slice(INPUT);
+            assert_eq!(&buf[..INPUT.len()], INPUT);
+            black_box(&buf[..]);
+        })
     });
 }
 

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -1,0 +1,26 @@
+#![feature(test)]
+extern crate test;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn bench_bufpool(c: &mut Criterion) {
+    c.bench_function("alloc bufpool", |b| {
+        b.iter(|| {
+            for _ in 0..100_000 {
+                let buf = alt_http::bufpool::Buf::alloc().unwrap();
+                black_box(&buf[..]);
+            }
+        })
+    });
+    c.bench_function("alloc vec", |b| {
+        b.iter(|| {
+            for _ in 0..100_000 {
+                let buf: Vec<u8> = Vec::with_capacity(1024);
+                black_box(&buf[..]);
+            }
+        })
+    });
+}
+
+criterion_group!(benches, bench_bufpool);
+criterion_main!(benches);

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -1,38 +1,72 @@
 #![feature(test)]
 extern crate test;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
 static INPUT: &[u8] = b"This is some sample data";
 
 fn bench_bufpool(c: &mut Criterion) {
-    let mut g = c.benchmark_group("alloc");
+    {
+        let mut g = c.benchmark_group("alloc");
 
-    g.bench_function("0-stack", |b| {
-        b.iter(|| {
-            let mut buf = [0u8; 4096];
-            buf[..INPUT.len()].copy_from_slice(INPUT);
-            assert_eq!(&buf[..INPUT.len()], INPUT);
-            black_box(&buf[..]);
-        })
-    });
-    g.bench_function("1-pool", |b| {
-        b.iter(|| {
-            let mut buf = alt_http::bufpool::Buf::alloc().unwrap();
-            buf[..INPUT.len()].copy_from_slice(INPUT);
-            assert_eq!(&buf[..INPUT.len()], INPUT);
-            black_box(&buf[..]);
-        })
-    });
-    g.bench_function("2-vec", |b| {
-        b.iter(|| {
-            let mut buf: Vec<u8> = Vec::with_capacity(4096);
-            buf.resize(INPUT.len(), 0);
-            buf[..INPUT.len()].copy_from_slice(INPUT);
-            assert_eq!(&buf[..INPUT.len()], INPUT);
-            black_box(&buf[..]);
-        })
-    });
+        g.bench_function("0-stack", |b| {
+            b.iter(|| {
+                let mut buf = [0u8; 4096];
+                buf[..INPUT.len()].copy_from_slice(INPUT);
+                assert_eq!(&buf[..INPUT.len()], INPUT);
+                black_box(&buf[..]);
+            })
+        });
+        g.bench_function("pool", |b| {
+            b.iter(|| {
+                let mut buf = alt_http::bufpool::Buf::alloc().unwrap();
+                buf[..INPUT.len()].copy_from_slice(INPUT);
+                assert_eq!(&buf[..INPUT.len()], INPUT);
+                black_box(&buf[..]);
+            })
+        });
+        g.bench_function("vec", |b| {
+            b.iter(|| {
+                let mut buf: Vec<u8> = Vec::with_capacity(4096);
+                buf.resize(INPUT.len(), 0);
+                buf[..INPUT.len()].copy_from_slice(INPUT);
+                assert_eq!(&buf[..INPUT.len()], INPUT);
+                black_box(&buf[..]);
+            })
+        });
+    }
+
+    {
+        let mut g = c.benchmark_group("alloc-many");
+
+        for count in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] {
+            g.bench_with_input(BenchmarkId::new("pool", count), &count, |b, &s| {
+                b.iter(|| {
+                    let mut bufs = Vec::with_capacity(s);
+                    for _ in 0..s {
+                        let mut buf = alt_http::bufpool::Buf::alloc().unwrap();
+                        buf[..INPUT.len()].copy_from_slice(INPUT);
+                        assert_eq!(&buf[..INPUT.len()], INPUT);
+                        bufs.push(buf);
+                    }
+                    black_box(bufs);
+                })
+            });
+            g.bench_with_input(BenchmarkId::new("vec", count), &count, |b, &s| {
+                b.iter(|| {
+                    let mut bufs = Vec::with_capacity(s);
+                    for _ in 0..s {
+                        let mut buf: Vec<u8> = Vec::with_capacity(4096);
+                        buf.resize(INPUT.len(), 0);
+                        buf[..INPUT.len()].copy_from_slice(INPUT);
+                        assert_eq!(&buf[..INPUT.len()], INPUT);
+                        bufs.push(buf);
+                    }
+                    black_box(bufs);
+                })
+            });
+        }
+    }
 }
 
 criterion_group!(benches, bench_bufpool);

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -6,22 +6,44 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 static INPUT: &[u8] = b"This is some sample data";
 
 fn bench_bufpool(c: &mut Criterion) {
-    c.bench_function("alloc bufpool", |b| {
-        b.iter(|| {
-            let mut buf = alt_http::bufpool::Buf::alloc().unwrap();
-            buf[..INPUT.len()].copy_from_slice(INPUT);
-            assert_eq!(&buf[..INPUT.len()], INPUT);
-            black_box(&buf[..]);
-        })
+    let mut g = c.benchmark_group("alloc");
+
+    g.bench_function("noop", |b| b.iter_with_setup(|| {}, |_| {}));
+    g.bench_function("buf-unchecked", |b| {
+        b.iter_with_setup(
+            || {
+                alt_http::bufpool::init().unwrap();
+            },
+            |_| {
+                let mut buf = alt_http::bufpool::Buf::alloc_unchecked().unwrap();
+                buf[..INPUT.len()].copy_from_slice(INPUT);
+                assert_eq!(&buf[..INPUT.len()], INPUT);
+                black_box(&buf[..]);
+            },
+        )
     });
-    c.bench_function("alloc vec", |b| {
-        b.iter(|| {
-            let mut buf: Vec<u8> = Vec::with_capacity(1024);
-            buf.resize(INPUT.len(), 0);
-            buf[..INPUT.len()].copy_from_slice(INPUT);
-            assert_eq!(&buf[..INPUT.len()], INPUT);
-            black_box(&buf[..]);
-        })
+    g.bench_function("buf-checked", |b| {
+        b.iter_with_setup(
+            || {},
+            |_| {
+                let mut buf = alt_http::bufpool::Buf::alloc().unwrap();
+                buf[..INPUT.len()].copy_from_slice(INPUT);
+                assert_eq!(&buf[..INPUT.len()], INPUT);
+                black_box(&buf[..]);
+            },
+        )
+    });
+    g.bench_function("vec", |b| {
+        b.iter_with_setup(
+            || {},
+            |_| {
+                let mut buf: Vec<u8> = Vec::with_capacity(4096);
+                buf.resize(INPUT.len(), 0);
+                buf[..INPUT.len()].copy_from_slice(INPUT);
+                assert_eq!(&buf[..INPUT.len()], INPUT);
+                black_box(&buf[..]);
+            },
+        )
     });
 }
 

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -3,21 +3,24 @@ extern crate test;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
+static INPUT: &[u8] = b"This is some sample data";
+
 fn bench_bufpool(c: &mut Criterion) {
     c.bench_function("alloc bufpool", |b| {
         b.iter(|| {
-            for _ in 0..100_000 {
-                let buf = alt_http::bufpool::Buf::alloc().unwrap();
-                black_box(&buf[..]);
-            }
+            let mut buf = alt_http::bufpool::Buf::alloc().unwrap();
+            buf[..INPUT.len()].copy_from_slice(INPUT);
+            assert_eq!(&buf[..INPUT.len()], INPUT);
+            black_box(&buf[..]);
         })
     });
     c.bench_function("alloc vec", |b| {
         b.iter(|| {
-            for _ in 0..100_000 {
-                let buf: Vec<u8> = Vec::with_capacity(1024);
-                black_box(&buf[..]);
-            }
+            let mut buf: Vec<u8> = Vec::with_capacity(1024);
+            buf.resize(INPUT.len(), 0);
+            buf[..INPUT.len()].copy_from_slice(INPUT);
+            assert_eq!(&buf[..INPUT.len()], INPUT);
+            black_box(&buf[..]);
         })
     });
 }

--- a/src/bufpool.rs
+++ b/src/bufpool.rs
@@ -42,19 +42,6 @@ impl BufPool {
         }
     }
 
-    pub(crate) fn alloc_unchecked(&self) -> Result<Buf> {
-        let mut inner = self.borrow_mut_unchecked();
-
-        if let Some(index) = inner.free.pop_front() {
-            Ok(Buf {
-                index,
-                _non_send: Default::default(),
-            })
-        } else {
-            Err(Error::OutOfMemory)
-        }
-    }
-
     pub(crate) fn alloc(&self) -> Result<Buf> {
         let mut inner = self.borrow_mut()?;
 
@@ -95,13 +82,6 @@ impl BufPool {
         let r = RefMut::map(inner, |o| o.as_mut().unwrap());
         Ok(r)
     }
-
-    #[inline(always)]
-    fn borrow_mut_unchecked(&self) -> RefMut<BufPoolInner> {
-        RefMut::map(self.inner.borrow_mut(), |o| unsafe {
-            o.as_mut().unwrap_unchecked()
-        })
-    }
 }
 
 pub fn init() -> Result<()> {
@@ -119,11 +99,6 @@ impl Buf {
     #[inline(always)]
     pub fn alloc() -> Result<Buf, Error> {
         BUF_POOL.alloc()
-    }
-
-    #[inline(always)]
-    pub fn alloc_unchecked() -> Result<Buf, Error> {
-        BUF_POOL.alloc_unchecked()
     }
 
     pub fn len() -> usize {

--- a/src/bufpool.rs
+++ b/src/bufpool.rs
@@ -1,0 +1,144 @@
+use std::{cell::RefCell, collections::VecDeque, marker::PhantomData, ops, rc::Rc};
+
+use memmap2::MmapMut;
+
+thread_local! {
+    static BUF_POOL: Rc<BufPool> = Rc::new(BufPool::new(4096, 1024).unwrap());
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("could not mmap buffer")]
+    Mmap(#[from] std::io::Error),
+
+    #[error("out of memory")]
+    OutOfMemory,
+}
+
+/// A buffer pool
+pub(crate) struct BufPool {
+    map: MmapMut,
+    ptr: *mut u8,
+    buf_size: usize,
+    num_buf: usize,
+    inner: RefCell<BufPoolInner>,
+}
+
+struct BufPoolInner {
+    free: VecDeque<u16>,
+}
+
+impl BufPool {
+    pub(crate) fn new(buf_size: u16, num_buf: u16) -> Result<BufPool, Error> {
+        let len = num_buf as usize * buf_size as usize;
+        let mut map = memmap2::MmapOptions::new().len(len).map_anon()?;
+        let ptr = map.as_mut_ptr();
+
+        let mut free = VecDeque::with_capacity(num_buf as usize);
+        for i in 0..num_buf {
+            free.push_back(i);
+        }
+
+        let inner = BufPoolInner { free };
+        Ok(BufPool {
+            map,
+            ptr,
+            buf_size: buf_size as usize,
+            num_buf: num_buf as usize,
+            inner: RefCell::new(inner),
+        })
+    }
+
+    pub(crate) fn alloc(self: &Rc<Self>) -> Result<Buf, Error> {
+        let mut inner = self.inner.borrow_mut();
+        if let Some(index) = inner.free.pop_front() {
+            Ok(Buf {
+                index,
+                _non_send: Default::default(),
+            })
+        } else {
+            Err(Error::OutOfMemory)
+        }
+    }
+
+    fn reclaim(&self, index: u16) {
+        let mut inner = self.inner.borrow_mut();
+        inner.free.push_back(index);
+    }
+
+    fn num_free(&self) -> usize {
+        self.inner.borrow().free.len()
+    }
+}
+
+pub struct Buf {
+    index: u16,
+    // makes this type non-Send
+    _non_send: PhantomData<*mut ()>,
+}
+
+impl Buf {
+    pub fn alloc() -> Result<Buf, Error> {
+        BUF_POOL.with(|pool| pool.alloc())
+    }
+
+    pub fn len() -> usize {
+        BUF_POOL.with(|pool| pool.buf_size)
+    }
+}
+
+impl ops::Deref for Buf {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        BUF_POOL.with(|pool| {
+            let start = self.index as usize * pool.buf_size;
+            // TODO: review safety of this. the thread can end, which would run
+            // the destructor, drop the `MmapMut`, and unmap the memory. but
+            // `Buf` is !Send and !Sync, and the returned slice has the same
+            // lifetime as `Buf`, so I think this is okay? - amos
+            unsafe { std::slice::from_raw_parts(pool.ptr.add(start), pool.buf_size) }
+        })
+    }
+}
+
+impl ops::DerefMut for Buf {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        BUF_POOL.with(|pool| {
+            let start = self.index as usize * pool.buf_size;
+            unsafe { std::slice::from_raw_parts_mut(pool.ptr.add(start), pool.buf_size) }
+        })
+    }
+}
+
+impl Drop for Buf {
+    fn drop(&mut self) {
+        BUF_POOL.with(|pool| pool.reclaim(self.index));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bufpool::BUF_POOL;
+
+    use super::Buf;
+
+    #[test]
+    fn simple_bufpool_test() {
+        let initial_free = BUF_POOL.with(|pool| pool.num_free());
+
+        let mut buf = Buf::alloc().unwrap();
+
+        let now_free = BUF_POOL.with(|pool| pool.num_free());
+        assert_eq!(initial_free - 1, now_free);
+        assert_eq!(buf.len(), 4096);
+
+        buf[..11].copy_from_slice(b"hello world");
+        assert_eq!(&buf[..11], b"hello world");
+
+        drop(buf);
+
+        let now_free = BUF_POOL.with(|pool| pool.num_free());
+        assert_eq!(initial_free, now_free);
+    }
+}

--- a/src/bufpool.rs
+++ b/src/bufpool.rs
@@ -8,7 +8,7 @@ use std::{
 use memmap2::MmapMut;
 
 #[thread_local]
-static BUF_POOL: BufPool = BufPool::new_empty(4096, 1024);
+static BUF_POOL: BufPool = BufPool::new_empty(4096, 4096);
 
 thread_local! {
     static BUF_POOL_DESTRUCTOR: RefCell<Option<MmapMut>> = RefCell::new(None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(thread_local)]
+
 use eyre::Context;
 use futures::FutureExt;
 use httparse::{Request, Response, Status, EMPTY_HEADER};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ use tracing::debug;
 const MAX_HEADERS_LEN: usize = 64 * 1024;
 const MAX_READ_SIZE: usize = 4 * 1024;
 
+mod bufpool;
+
 pub use httparse;
 
 /// re-exported so consumers can use whatever forked version we use

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 const MAX_HEADERS_LEN: usize = 64 * 1024;
 const MAX_READ_SIZE: usize = 4 * 1024;
 
-mod bufpool;
+pub mod bufpool;
 
 pub use httparse;
 


### PR DESCRIPTION
This adds a naive (but fast) buffer pool.

It's all hardcoded at 4096 x 4KiB buffers (16MiB total), and leaks memory on thread exit. It doesn't allow refcounting slices (like https://lib.rs/crates/bytes does) yet, and there can never be more than 65536 buffers because the index used is a `u16`.

Everything about it may change, but it's a good enough starting point that I'm going to merge this.

## Bad benchmarks

I don't know how to benchmark this properly, these probably don't mean anything.

For one alloc:

<img width="916" alt="image" src="https://user-images.githubusercontent.com/7998310/195101757-11a5ee78-7aee-443d-a87f-fad02850b8bf.png">

For multiple allocs (16 to 4096 buffers), pool vs just `Vec::new`

<img width="919" alt="image" src="https://user-images.githubusercontent.com/7998310/195101817-b58c4123-c456-426e-a967-c363974c604a.png">

Details for vec:

<img width="906" alt="image" src="https://user-images.githubusercontent.com/7998310/195101976-9ff0678e-8ba5-4b60-a388-85d59ec1d030.png">

Details for pool:

<img width="921" alt="image" src="https://user-images.githubusercontent.com/7998310/195102040-2456495c-77c2-4812-a238-1c3e8f92334d.png">
