### PR TITLE
Free allocated memory at thread exit

### DIFF
--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -53,7 +53,7 @@ fn bench_bufpool(c: &mut Criterion) {
     {
         let mut g = c.benchmark_group("alloc-many");
 
-        for count in [16, 32, 64, 128, 256, 512, 1024, 2048, 4096] {
+        for count in [256, 512, 1024, 2048, 4096] {
             g.bench_with_input(BenchmarkId::new("pool", count), &count, |b, &s| {
                 b.iter(|| {
                     let mut bufs = Vec::with_capacity(s);


### PR DESCRIPTION
Use a `thread_local!` to run thread destructors, because `#[thread_local]` is fast, but doesn't support them. This is only initialized once per thread, so it's still just as cheap.