### PR TITLE
Refactor tests a little, return 431 for headers too large

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,12 @@ tokio-uring = { git = "https://github.com/tokio-rs/tokio-uring", rev = "a42af77"
 tracing = "0.1.37"
 
 [dev-dependencies]
+bytes = "1.2.1"
 color-eyre = "0.6.2"
 criterion = "0.4.0"
 hyper = { version = "0.14.20", features = ["client", "server", "http1", "tcp", "stream"] }
+pretty_assertions = "1.3.0"
 tracing-subscriber = "0.3.16"
+
+[profile.dev.package."*"]
+opt-level = 2

--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,9 @@ _default:
 # Run all tests with cargo nextest
 test *args:
 	RUST_BACKTRACE=1 cargo nextest run {{args}}
+	
+single-test *args:
+	just test --no-capture {{args}}
 
 bench *args:
 	RUST_BACKTRACE=1 cargo bench {{args}} -- --plotting-backend plotters

--- a/tests/helpers/fixed_driver.rs
+++ b/tests/helpers/fixed_driver.rs
@@ -1,0 +1,31 @@
+use std::net::SocketAddr;
+
+use alt_http::{ConnectionDriver, RequestDriver};
+
+pub(crate) struct FixedConnDriver {
+    pub(crate) upstream_addr: SocketAddr,
+}
+
+pub(crate) struct FixedReqDriver {
+    upstream_addr: SocketAddr,
+}
+
+impl ConnectionDriver for FixedConnDriver {
+    type RequestDriver = FixedReqDriver;
+
+    fn build_request_context(&self, _req: &httparse::Request) -> eyre::Result<Self::RequestDriver> {
+        Ok(FixedReqDriver {
+            upstream_addr: self.upstream_addr,
+        })
+    }
+}
+
+impl RequestDriver for FixedReqDriver {
+    fn upstream_addr(&self) -> eyre::Result<std::net::SocketAddr> {
+        Ok(self.upstream_addr)
+    }
+
+    fn keep_header(&self, _name: &str) -> bool {
+        true
+    }
+}

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,5 +1,6 @@
 use std::{convert::Infallible, future::Future, net::SocketAddr, rc::Rc};
 
+use futures::FutureExt;
 use hyper::service::make_service_fn;
 use tracing::debug;
 
@@ -22,18 +23,23 @@ pub(crate) fn run(test: impl Future<Output = eyre::Result<()>>) {
 
 pub(crate) fn tcp_serve_h1_once(
 ) -> eyre::Result<(SocketAddr, impl Future<Output = eyre::Result<()>>)> {
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+
     let upstream =
         hyper::Server::bind(&"[::]:0".parse()?).serve(make_service_fn(|_addr| async move {
             Ok::<_, Infallible>(TestService)
         }));
     let upstream_addr = upstream.local_addr();
+    let upstream = upstream.with_graceful_shutdown(rx.map(|_| ()));
 
     let ln = tokio_uring::net::TcpListener::bind("[::]:0".parse()?)?;
     let ln_addr = ln.local_addr()?;
     let conn_dv = Rc::new(FixedConnDriver { upstream_addr });
 
     let upstream_fut = async move {
+        debug!("Started h1 server");
         upstream.await?;
+        debug!("Done with h1 server");
         Ok::<_, eyre::Report>(())
     };
 
@@ -41,6 +47,8 @@ pub(crate) fn tcp_serve_h1_once(
         let (stream, remote_addr) = ln.accept().await?;
         debug!("Accepted connection from {remote_addr}");
         alt_http::serve_h1(conn_dv, stream).await?;
+        debug!("Done serving h1 connection, initiating graceful shutdown");
+        drop(tx);
         Ok(())
     };
 

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,0 +1,15 @@
+use std::future::Future;
+
+pub(crate) mod sample_hyper_server;
+pub(crate) mod tracing_common;
+
+pub(crate) fn run(test: impl Future<Output = eyre::Result<()>>) {
+    tokio_uring::start(async {
+        tracing_common::setup_tracing();
+        color_eyre::install().unwrap();
+
+        if let Err(e) = test.await {
+            panic!("Error: {}", e);
+        }
+    });
+}

--- a/tests/helpers/sample_hyper_server.rs
+++ b/tests/helpers/sample_hyper_server.rs
@@ -1,0 +1,27 @@
+use std::convert::Infallible;
+
+use futures::Future;
+use hyper::{service::Service, Body, Request, Response};
+
+pub(crate) struct TestService;
+
+impl Service<Request<Body>> for TestService {
+    type Response = Response<Body>;
+    type Error = Infallible;
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        Ok(()).into()
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        async move {
+            let (_parts, body) = req.into_parts();
+            let res = Response::builder().body(body).unwrap();
+            Ok(res)
+        }
+    }
+}

--- a/tests/helpers/tracing_common.rs
+++ b/tests/helpers/tracing_common.rs
@@ -1,0 +1,22 @@
+use tracing::Level;
+use tracing_subscriber::{filter::Targets, layer::SubscriberExt, util::SubscriberInitExt};
+
+/// Set up a global tracing subscriber.
+///
+/// This won't play well outside of cargo-nextest or running a single
+/// test, which is a limitation we accept.
+pub(crate) fn setup_tracing() {
+    let filter_layer = Targets::new()
+        .with_default(Level::DEBUG)
+        .with_target("want", Level::INFO);
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_file(true)
+        .with_line_number(true)
+        .with_thread_ids(true);
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .init();
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,38 +2,131 @@
 
 mod helpers;
 
-use hyper::{Body, Request};
+use bytes::BytesMut;
+use httparse::{Status, EMPTY_HEADER};
+use pretty_assertions::assert_eq;
 use std::net::SocketAddr;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+};
+use tracing::debug;
 
 use crate::helpers::tcp_serve_h1_once;
 
+// Test ideas:
+// headers too large (ups/dos)
+// too many headers (ups/dos)
+// invalid transfer-encoding header
+// chunked transfer-encoding but bad chunks
+// various timeouts (slowloris, idle body, etc.)
+
 #[test]
-fn test_simple_server() {
+fn header_too_large() {
+    async fn client(ln_addr: SocketAddr) -> eyre::Result<()> {
+        let mut socket = TcpStream::connect(ln_addr).await?;
+        socket.set_nodelay(true)?;
+
+        debug!("Making request...");
+        socket.write_all(b"POST /hi HTTP/1.1\r\ntoo-long: ").await?;
+
+        let garbage = "o".repeat(32678);
+        let mut conn_reset = false;
+
+        for _ in 0..128 {
+            debug!("writing...");
+            if let Err(e) = socket.write_all(garbage.as_bytes()).await {
+                if e.kind() == std::io::ErrorKind::ConnectionReset {
+                    debug!("connection reset, as expected");
+                    conn_reset = true;
+                    break;
+                } else {
+                    return Err(e.into());
+                }
+            };
+        }
+        assert!(conn_reset);
+
+        debug!("reading response");
+        let mut buf = BytesMut::new();
+        socket.read_buf(&mut buf).await?;
+        debug!("got response: {:?}", String::from_utf8_lossy(&buf[..]));
+
+        let mut headers = [EMPTY_HEADER; 16];
+        let mut res = httparse::Response::new(&mut headers[..]);
+        let _body_offset = match res.parse(&buf[..])? {
+            Status::Complete(off) => off,
+            Status::Partial => panic!("partial response"),
+        };
+
+        assert_eq!(res.code, Some(431));
+        assert_eq!(res.reason, Some("Request Header Fields Too Large"));
+
+        debug!("Done with client altogether");
+
+        Ok(())
+    }
+
     helpers::run(async move {
         let (server_addr, server_fut) = tcp_serve_h1_once()?;
-        let client_fut = do_client(server_addr);
+        let client_fut = client(server_addr);
 
         tokio::try_join!(server_fut, client_fut)?;
         Ok(())
     })
 }
 
-async fn do_client(ln_addr: SocketAddr) -> eyre::Result<()> {
-    let test_body = "A fairly simple request body";
+#[test]
+fn simple_post() {
+    async fn client(ln_addr: SocketAddr) -> eyre::Result<()> {
+        let test_body = "A fairly simple request body";
+        let content_length = test_body.len();
+        let mut socket = TcpStream::connect(ln_addr).await?;
+        socket.set_nodelay(true)?;
 
-    let client = hyper::Client::new();
-    let req = Request::builder()
-        .uri(format!("http://{ln_addr}/hi"))
-        .body(Body::from(test_body))
-        .unwrap();
+        debug!("Sending request headers...");
+        socket
+        .write_all(
+            format!("POST /hi HTTP/1.1\r\ncontent-length: {content_length}\r\nconnection: close\r\n\r\n").as_bytes(),
+        )
+        .await?;
 
-    let res = client.request(req).await.unwrap();
-    dbg!(res.headers());
-    let body = hyper::body::to_bytes(res.into_body())
-        .await
-        .unwrap()
-        .to_vec();
-    assert_eq!(body, test_body.as_bytes());
+        debug!("Sending request body...");
+        socket.write_all(test_body.as_bytes()).await?;
 
-    Ok(())
+        socket.flush().await?;
+
+        debug!("Reading response...");
+        let mut buf = Vec::new();
+        socket.read_to_end(&mut buf).await?;
+        debug!("Done reading response");
+
+        let mut headers = [EMPTY_HEADER; 16];
+        let mut res = httparse::Response::new(&mut headers[..]);
+        let body_offset = match res.parse(&buf[..])? {
+            Status::Complete(off) => off,
+            Status::Partial => panic!("partial response"),
+        };
+
+        let body_len = buf.len() - body_offset;
+        assert_eq!(content_length, body_len);
+
+        assert_eq!(res.code, Some(200));
+        assert_eq!(res.headers.len(), 2);
+
+        let received_body = &buf[body_offset..];
+        assert_eq!(test_body.as_bytes(), received_body);
+
+        debug!("Done with client altogether");
+
+        Ok(())
+    }
+
+    helpers::run(async move {
+        let (server_addr, server_fut) = tcp_serve_h1_once()?;
+        let client_fut = client(server_addr);
+
+        tokio::try_join!(server_fut, client_fut)?;
+        Ok(())
+    })
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,125 +1,71 @@
 #![feature(type_alias_impl_trait)]
 
-use std::{convert::Infallible, future::Future, net::SocketAddr, rc::Rc};
+mod helpers;
+
+use std::{convert::Infallible, net::SocketAddr, rc::Rc};
 
 use alt_http::{ConnectionDriver, RequestDriver};
-use hyper::{
-    service::{make_service_fn, Service},
-    Body, Request, Response,
-};
-use tracing::Level;
-use tracing_subscriber::{filter::Targets, layer::SubscriberExt, util::SubscriberInitExt};
+use hyper::{service::make_service_fn, Body, Request};
 
-struct TestService;
-
-impl Service<Request<Body>> for TestService {
-    type Response = Response<Body>;
-    type Error = Infallible;
-    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(
-        &mut self,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        Ok(()).into()
-    }
-
-    fn call(&mut self, req: Request<Body>) -> Self::Future {
-        async move {
-            let (_parts, body) = req.into_parts();
-            let res = Response::builder().body(body).unwrap();
-            Ok(res)
-        }
-    }
-}
-
-/// Set up a global tracing subscriber.
-///
-/// This won't play well outside of cargo-nextest or running a single
-/// test, which is a limitation we accept.
-fn setup_tracing() {
-    let filter_layer = Targets::new()
-        .with_default(Level::DEBUG)
-        .with_target("want", Level::INFO);
-
-    let fmt_layer = tracing_subscriber::fmt::layer()
-        .with_file(true)
-        .with_line_number(true)
-        .with_thread_ids(true);
-
-    tracing_subscriber::registry()
-        .with(filter_layer)
-        .with(fmt_layer)
-        .init();
-}
-
-fn run(test: impl Future<Output = eyre::Result<()>>) {
-    tokio_uring::start(async {
-        setup_tracing();
-        color_eyre::install().unwrap();
-
-        if let Err(e) = test.await {
-            panic!("Error: {}", e);
-        }
-    });
-}
+use crate::helpers::sample_hyper_server::TestService;
 
 #[test]
 fn test_simple_server() {
-    run(test_simple_server_inner())
-}
+    helpers::run(test_simple_server_inner());
 
-async fn test_simple_server_inner() -> eyre::Result<()> {
-    let upstream = hyper::Server::bind(&"[::]:0".parse()?).serve(make_service_fn(|_addr| async {
-        Ok::<_, Infallible>(TestService)
-    }));
-    let upstream_addr = upstream.local_addr();
-    tokio_uring::spawn(upstream);
+    async fn test_simple_server_inner() -> eyre::Result<()> {
+        let upstream =
+            hyper::Server::bind(&"[::]:0".parse()?).serve(make_service_fn(|_addr| async {
+                Ok::<_, Infallible>(TestService)
+            }));
+        let upstream_addr = upstream.local_addr();
+        tokio_uring::spawn(upstream);
 
-    let ln = tokio_uring::net::TcpListener::bind("[::]:0".parse()?)?;
-    let ln_addr = ln.local_addr()?;
+        let ln = tokio_uring::net::TcpListener::bind("[::]:0".parse()?)?;
+        let ln_addr = ln.local_addr()?;
 
-    let client_jh = tokio_uring::spawn(do_client(ln_addr));
+        let client_jh = tokio_uring::spawn(do_client(ln_addr));
 
-    struct CDriver {
-        upstream_addr: SocketAddr,
-    }
-
-    struct RDriver {
-        upstream_addr: SocketAddr,
-    }
-
-    impl ConnectionDriver for CDriver {
-        type RequestDriver = RDriver;
-
-        fn build_request_context(
-            &self,
-            _req: &httparse::Request,
-        ) -> eyre::Result<Self::RequestDriver> {
-            Ok(RDriver {
-                upstream_addr: self.upstream_addr,
-            })
-        }
-    }
-
-    impl RequestDriver for RDriver {
-        fn upstream_addr(&self) -> eyre::Result<std::net::SocketAddr> {
-            Ok(self.upstream_addr)
+        struct CDriver {
+            upstream_addr: SocketAddr,
         }
 
-        fn keep_header(&self, _name: &str) -> bool {
-            true
+        struct RDriver {
+            upstream_addr: SocketAddr,
         }
+
+        impl ConnectionDriver for CDriver {
+            type RequestDriver = RDriver;
+
+            fn build_request_context(
+                &self,
+                _req: &httparse::Request,
+            ) -> eyre::Result<Self::RequestDriver> {
+                Ok(RDriver {
+                    upstream_addr: self.upstream_addr,
+                })
+            }
+        }
+
+        impl RequestDriver for RDriver {
+            fn upstream_addr(&self) -> eyre::Result<std::net::SocketAddr> {
+                Ok(self.upstream_addr)
+            }
+
+            fn keep_header(&self, _name: &str) -> bool {
+                true
+            }
+        }
+
+        let conn_dv = Rc::new(CDriver { upstream_addr });
+
+        let (stream, _remote_addr) = ln.accept().await?;
+        alt_http::serve_h1(conn_dv, stream).await?;
+
+        client_jh.await??;
+
+        Ok(())
     }
-
-    let conn_dv = Rc::new(CDriver { upstream_addr });
-
-    let (stream, _remote_addr) = ln.accept().await?;
-    alt_http::serve_h1(conn_dv, stream).await?;
-
-    client_jh.await??;
-
-    Ok(())
 }
 
 async fn do_client(ln_addr: SocketAddr) -> eyre::Result<()> {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -5,7 +5,7 @@ mod helpers;
 use bytes::BytesMut;
 use httparse::{Status, EMPTY_HEADER};
 use pretty_assertions::assert_eq;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpStream,
@@ -44,6 +44,8 @@ fn header_too_large() {
                     return Err(e.into());
                 }
             };
+            // this isn't great, but we're waiting for a connection reset
+            tokio::time::sleep(Duration::from_millis(1)).await;
         }
         assert!(conn_reset);
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,70 +2,20 @@
 
 mod helpers;
 
-use std::{convert::Infallible, net::SocketAddr, rc::Rc};
+use hyper::{Body, Request};
+use std::net::SocketAddr;
 
-use alt_http::{ConnectionDriver, RequestDriver};
-use hyper::{service::make_service_fn, Body, Request};
-
-use crate::helpers::sample_hyper_server::TestService;
+use crate::helpers::tcp_serve_h1_once;
 
 #[test]
 fn test_simple_server() {
-    helpers::run(test_simple_server_inner());
+    helpers::run(async move {
+        let (server_addr, server_fut) = tcp_serve_h1_once()?;
+        let client_fut = do_client(server_addr);
 
-    async fn test_simple_server_inner() -> eyre::Result<()> {
-        let upstream =
-            hyper::Server::bind(&"[::]:0".parse()?).serve(make_service_fn(|_addr| async {
-                Ok::<_, Infallible>(TestService)
-            }));
-        let upstream_addr = upstream.local_addr();
-        tokio_uring::spawn(upstream);
-
-        let ln = tokio_uring::net::TcpListener::bind("[::]:0".parse()?)?;
-        let ln_addr = ln.local_addr()?;
-
-        let client_jh = tokio_uring::spawn(do_client(ln_addr));
-
-        struct CDriver {
-            upstream_addr: SocketAddr,
-        }
-
-        struct RDriver {
-            upstream_addr: SocketAddr,
-        }
-
-        impl ConnectionDriver for CDriver {
-            type RequestDriver = RDriver;
-
-            fn build_request_context(
-                &self,
-                _req: &httparse::Request,
-            ) -> eyre::Result<Self::RequestDriver> {
-                Ok(RDriver {
-                    upstream_addr: self.upstream_addr,
-                })
-            }
-        }
-
-        impl RequestDriver for RDriver {
-            fn upstream_addr(&self) -> eyre::Result<std::net::SocketAddr> {
-                Ok(self.upstream_addr)
-            }
-
-            fn keep_header(&self, _name: &str) -> bool {
-                true
-            }
-        }
-
-        let conn_dv = Rc::new(CDriver { upstream_addr });
-
-        let (stream, _remote_addr) = ln.accept().await?;
-        alt_http::serve_h1(conn_dv, stream).await?;
-
-        client_jh.await??;
-
+        tokio::try_join!(server_fut, client_fut)?;
         Ok(())
-    }
+    })
 }
 
 async fn do_client(ln_addr: SocketAddr) -> eyre::Result<()> {


### PR DESCRIPTION
There should be coverage for various buffering shenanigans, invalid HTTP, etc.